### PR TITLE
msgs: allow servers to report multiple error codes

### DIFF
--- a/industrial_msgs/msg/RobotStatus.msg
+++ b/industrial_msgs/msg/RobotStatus.msg
@@ -28,5 +28,8 @@ industrial_msgs/TriState in_motion
 # or may not be affected (see motion_possible)
 industrial_msgs/TriState in_error
 
-# Error code: Vendor specific error code (non zero indicates error)
-int32 error_code
+# Error code: Vendor specific error codes. If this list is empty, there are
+# no active errors on the controller. Order of entries in this list does
+# not necessarily encode for any specific severity or priority of active
+# errors.
+int32[] error_codes


### PR DESCRIPTION
As per subject.

The main motivation for this change is a development in MotoROS2, where we'd like to be able to report multiple active alarms and errors. With `error_code` being a scalar, that was not possible, so changing it to a list was necessary.

As the ability to report multiple activate alarms at the same time is something that can be generalised across different vendors, I'd like to merge this change here, upstream. However, I don't intend to merge this into `melodic-devel`, as this is a breaking change and we can't introduce that in Melodic nor Noetic any more.

I wanted to open a PR to have a venue for any potential discussion about this, and eventually would merge this change (but not this PR) into the https://github.com/ros-industrial/industrial_core/compare/melodic-devel...ros2_msgs_only branch.
